### PR TITLE
Importation de Tkinter selon la version de Python

### DIFF
--- a/Programmations/Python/Version_1.0.0/POSL-Rover.py
+++ b/Programmations/Python/Version_1.0.0/POSL-Rover.py
@@ -3,9 +3,15 @@
 
 # -- IMPORTATION --
 
-#import Tkinter as tk
-import tkinter as tk
+#Librairies standards
+import sys
 import serial
+
+#Librariries graphique en fonction de la version de Python
+if sys.version_info[0]>=2:
+    import Tkinter as tk
+else:
+    import tkinter as tk
 
 # -- INTERFACE GRAPHIQUE
 class iface1(tk.Frame):


### PR DESCRIPTION
Salut Almisuifre,

Pour pouvoir faire tourner ton code Python sur ma machine, je dois importer Tkinter pour la V2 de Python. J'ai donc modifié ton code pour qu'il repère tout seul la version de Python et qu'il importe la bonne librairie.

C'est couillon, mais la différence entre Pyt1 et Pyt2+ est simplement au niveau de la majuscule !

Si tu le veux bien, je te propose de séparer ta partie applicative de ta partie graphique en créant les objets ad'hoc.

@+
Snif